### PR TITLE
Allow requests only from Telegram network

### DIFF
--- a/lambdas/bot-client/network.py
+++ b/lambdas/bot-client/network.py
@@ -1,0 +1,27 @@
+import ipaddress
+import requests
+import logging
+
+logging.getLogger().setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+__telegram_cidr_endpoint = "https://core.telegram.org/resources/cidr.txt"
+
+
+def __define_telegram_network():
+    response = requests.get(__telegram_cidr_endpoint)
+    for line in response.text.splitlines():
+        yield ipaddress.ip_network(line.strip())
+
+
+__telegram_networks = set(__define_telegram_network())
+logger.info(f"Telegram network: {__telegram_networks}")
+
+
+def from_telegram_network(address):
+    for network in __telegram_networks:
+        if ipaddress.ip_address(address) in network:
+            return True
+
+    return False


### PR DESCRIPTION
This forbids messages outside of Telegram network. However, we still need handle to endpoints:
 * setWebhook: doesn't really hurt if someone calls it, as it just sets the webhook and there is no way to set it to some other url
 * sendDirectMessage: somehow allow only to call by our aws services