### PR TITLE
Create endpoint to return real data from incidents

### DIFF
--- a/database/ddl/createTables.sql
+++ b/database/ddl/createTables.sql
@@ -29,7 +29,7 @@ create table ugt.incident
     created_on         timestamp with time zone not null
 );
 
-CREATE INDEX idx_incident_timestamp ON ugt.incident(incident_timestamp);
+CREATE INDEX idx_incident_timestamp_type ON ugt.incident(incident_timestamp, incident_type);
 
 create table ugt.incident_user
 (

--- a/database/ddl/createTables.sql
+++ b/database/ddl/createTables.sql
@@ -29,6 +29,8 @@ create table ugt.incident
     created_on         timestamp with time zone not null
 );
 
+CREATE INDEX idx_incident_timestamp ON ugt.incident(incident_timestamp);
+
 create table ugt.incident_user
 (
     user_id     uuid

--- a/lambdas/readIncidentHandler/index.js
+++ b/lambdas/readIncidentHandler/index.js
@@ -1,0 +1,54 @@
+require('aws-sdk');
+
+exports.handler = async (event) => {
+    const dataClient = require('data-api-client')({
+        secretArn: process.env.SECRET_ARN,
+        resourceArn: process.env.RDS_DB_ARN,
+        database: 'postgres'
+    });
+
+    const filter = event.queryStringParameters;
+    return {
+        statusCode: 200,
+        body: mapOutput(await selectIncidents(dataClient, filter))
+    };
+}
+
+const mapOutput = (incidents = []) => {
+    return JSON.stringify(incidents.map(i => {
+        return {
+            timestamp: i.incident_timestamp,
+            type: i.incident_type,
+            location: {
+                lat: i.location_lat,
+                lon: i.location_lon
+            },
+            distance: i.distance,
+            score: i.score
+        }
+    }));
+}
+
+const selectIncidents = async (dataClient, filter) => {
+    let selectIncidentQuery = 'SELECT * FROM ugt.incident WHERE 1 = 1';
+    const queryParams = {};
+
+    if(filter && filter.type) {
+        selectIncidentQuery += ' AND incident_type = :incident_type';
+        queryParams['incident_type'] = filter.type;
+    }
+
+    if(filter && filter.timestampFrom) {
+        selectIncidentQuery += ' AND incident_timestamp >= :timestamp_from::timestamp';
+        queryParams['timestamp_from'] = filter.timestampFrom;
+    }
+
+    if(filter && filter.timestampTo) {
+        selectIncidentQuery += ' AND incident_timestamp <= :timestamp_to::timestamp';
+        queryParams['timestamp_to'] = filter.timestampTo;
+    }
+
+    selectIncidentQuery += ' ORDER BY incident_timestamp desc';
+
+    return (await dataClient.query(selectIncidentQuery, queryParams)).records;
+}

--- a/lambdas/readIncidentHandler/package-lock.json
+++ b/lambdas/readIncidentHandler/package-lock.json
@@ -1,0 +1,43 @@
+{
+  "name": "readIncidentHandler",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "data-api-client": "^1.2.0"
+      }
+    },
+    "node_modules/data-api-client": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/data-api-client/-/data-api-client-1.2.0.tgz",
+      "integrity": "sha512-AGv4lWOF4RyoqUOLrYWbZeIP7eyFCM2UxGJ92XG9Q0xHofrT/67plprl0mAsxpAYdWQ8u0hLZFxC+iQSASsjgQ==",
+      "dependencies": {
+        "sqlstring": "^2.3.2"
+      }
+    },
+    "node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    }
+  },
+  "dependencies": {
+    "data-api-client": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/data-api-client/-/data-api-client-1.2.0.tgz",
+      "integrity": "sha512-AGv4lWOF4RyoqUOLrYWbZeIP7eyFCM2UxGJ92XG9Q0xHofrT/67plprl0mAsxpAYdWQ8u0hLZFxC+iQSASsjgQ==",
+      "requires": {
+        "sqlstring": "^2.3.2"
+      }
+    },
+    "sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg=="
+    }
+  }
+}

--- a/lambdas/readIncidentHandler/package.json
+++ b/lambdas/readIncidentHandler/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "data-api-client": "^1.2.0"
+  }
+}

--- a/lambdas/storeIncidentHandler/old_index.js
+++ b/lambdas/storeIncidentHandler/old_index.js
@@ -34,7 +34,7 @@ const getDbConnection = async() => {
     const { Pool } = require("pg");
     const SecretsManager = require('./SecretsManager.js');
 
-    var secretName = 'rds/aurora/pgsql';
+    var secretName = 'rds/aurora/reporting-incidents-serverless';
     var region = 'eu-central-1';
 
     var secretsManager = JSON.parse(await SecretsManager.getSecret(secretName, region));

--- a/terraform/policies/api-gateway-permission.json
+++ b/terraform/policies/api-gateway-permission.json
@@ -17,6 +17,13 @@
     {
       "Effect": "Allow",
       "Action": [
+        "lambda:InvokeFunction"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "sqs:GetQueueUrl",
         "sqs:ChangeMessageVisibility",
         "sqs:ListDeadLetterSourceQueues",

--- a/terraform/rds-aurora.tf
+++ b/terraform/rds-aurora.tf
@@ -25,6 +25,7 @@ resource "aws_rds_cluster" "cluster" {
 
 resource "aws_secretsmanager_secret" "rds_credentials" {
   name = "rds/aurora/${aws_rds_cluster.cluster.cluster_identifier}"
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "rds_credentials" {
@@ -36,7 +37,8 @@ resource "aws_secretsmanager_secret_version" "rds_credentials" {
   "engine": "postgres",
   "host": "${aws_rds_cluster.cluster.endpoint}",
   "port": ${aws_rds_cluster.cluster.port},
-  "dbClusterIdentifier": "${aws_rds_cluster.cluster.cluster_identifier}"
+  "dbClusterIdentifier": "${aws_rds_cluster.cluster.cluster_identifier}",
+  "database_name": "${aws_rds_cluster.cluster.database_name}"
 }
 EOF
 }


### PR DESCRIPTION
Create endpoint under API Gateway (GET /api/v1/incident) to return real data instead of mock. Mock data moved to /api/v1/incident/mock .

In the future, endpoint will be consumed from HeatMap.