### PR TITLE
Enable cors for GET on api/v1/incident and /api/v1/incident/mock endpoints

### DIFF
--- a/terraform/api-gtw.tf
+++ b/terraform/api-gtw.tf
@@ -50,6 +50,8 @@ resource "aws_api_gateway_deployment" "reporting-incidents-deployment" {
     aws_api_gateway_integration.reporting-incidents_incident-post_integration,
     aws_api_gateway_integration.reporting-incidents_incident-get_mock-integration,
     aws_api_gateway_integration.reporting-incidents_incident-get_integration,
+    aws_api_gateway_integration.reporting-incidents_cors-options-mock-incident_integration,
+    aws_api_gateway_integration.reporting-incidents_cors-options-incident_integration,
     aws_api_gateway_integration_response.reporting-incidents_incident-post-response_integration_200,
     aws_api_gateway_integration_response.reporting-incidents_incident-mock-get-response_integration_200,
     aws_api_gateway_method.reporting-incidents_get-mock-incident,
@@ -241,6 +243,138 @@ resource "aws_api_gateway_method_response" "reporting-incidents_incident-get-res
   resource_id = aws_api_gateway_resource.reporting-incidents_incident-resource.id
   http_method = aws_api_gateway_method.reporting-incidents_get-incident.http_method
   status_code = "200"
+}
+
+# Enable CORS on GET Incident endpoint
+resource "aws_api_gateway_method" "reporting-incidents_cors-options-incident" {
+  rest_api_id   = aws_api_gateway_rest_api.reporting-incidents.id
+  resource_id   = aws_api_gateway_resource.reporting-incidents_incident-resource.id
+  http_method   = "OPTIONS"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_method_response" "reporting-incidents_cors-options-incident_resource" {
+  depends_on = [
+    aws_api_gateway_method.reporting-incidents_cors-options-incident,
+  ]
+
+  rest_api_id = aws_api_gateway_rest_api.reporting-incidents.id
+  resource_id = aws_api_gateway_resource.reporting-incidents_incident-resource.id
+  http_method = aws_api_gateway_method.reporting-incidents_cors-options-incident.http_method
+  status_code = "200"
+
+  response_models = {
+    "application/json" = "Empty"
+  }
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = true
+    "method.response.header.Access-Control-Allow-Methods" = true
+    "method.response.header.Access-Control-Allow-Origin"  = true
+  }
+}
+
+resource "aws_api_gateway_integration" "reporting-incidents_cors-options-incident_integration" {
+  depends_on = [
+    aws_api_gateway_method.reporting-incidents_cors-options-incident,
+  ]
+
+  rest_api_id          = aws_api_gateway_rest_api.reporting-incidents.id
+  resource_id          = aws_api_gateway_resource.reporting-incidents_incident-resource.id
+  http_method          = aws_api_gateway_method.reporting-incidents_cors-options-incident.http_method
+  type                 = "MOCK"
+  passthrough_behavior = "WHEN_NO_MATCH"
+
+  request_templates = {
+    "application/json" = "{\"statusCode\": 200}"
+  }
+}
+
+resource "aws_api_gateway_integration_response" "reporting-incidents_cors-options-incident_integration-response" {
+  depends_on = [
+    aws_api_gateway_method_response.reporting-incidents_cors-options-incident_resource,
+  ]
+
+  rest_api_id = aws_api_gateway_rest_api.reporting-incidents.id
+  resource_id = aws_api_gateway_resource.reporting-incidents_incident-resource.id
+  http_method = aws_api_gateway_method.reporting-incidents_cors-options-incident.http_method
+  status_code = aws_api_gateway_method_response.reporting-incidents_cors-options-incident_resource.status_code
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
+    "method.response.header.Access-Control-Allow-Methods" = "'OPTIONS,GET'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+  }
+
+  response_templates = {
+    "application/json" = ""
+  }
+}
+
+# Enable CORS on Mock endpoint
+resource "aws_api_gateway_method" "reporting-incidents_cors-options-mock-incident" {
+  rest_api_id   = aws_api_gateway_rest_api.reporting-incidents.id
+  resource_id   = aws_api_gateway_resource.reporting-incidents_incident-mock-resource.id
+  http_method   = "OPTIONS"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_method_response" "reporting-incidents_cors-options-mock_resource" {
+  depends_on = [
+    aws_api_gateway_method.reporting-incidents_cors-options-mock-incident,
+  ]
+
+  rest_api_id = aws_api_gateway_rest_api.reporting-incidents.id
+  resource_id = aws_api_gateway_resource.reporting-incidents_incident-mock-resource.id
+  http_method = aws_api_gateway_method.reporting-incidents_cors-options-mock-incident.http_method
+  status_code = "200"
+
+  response_models = {
+    "application/json" = "Empty"
+  }
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = true
+    "method.response.header.Access-Control-Allow-Methods" = true
+    "method.response.header.Access-Control-Allow-Origin"  = true
+  }
+}
+
+resource "aws_api_gateway_integration" "reporting-incidents_cors-options-mock-incident_integration" {
+  depends_on = [
+    aws_api_gateway_method.reporting-incidents_cors-options-mock-incident,
+  ]
+
+  rest_api_id          = aws_api_gateway_rest_api.reporting-incidents.id
+  resource_id          = aws_api_gateway_resource.reporting-incidents_incident-mock-resource.id
+  http_method          = aws_api_gateway_method.reporting-incidents_cors-options-mock-incident.http_method
+  type                 = "MOCK"
+  passthrough_behavior = "WHEN_NO_MATCH"
+
+  request_templates = {
+    "application/json" = "{\"statusCode\": 200}"
+  }
+}
+
+resource "aws_api_gateway_integration_response" "reporting-incidents_cors-options-mock-incident_integration-response" {
+  depends_on = [
+    aws_api_gateway_method_response.reporting-incidents_cors-options-mock_resource,
+  ]
+
+  rest_api_id = aws_api_gateway_rest_api.reporting-incidents.id
+  resource_id = aws_api_gateway_resource.reporting-incidents_incident-mock-resource.id
+  http_method = aws_api_gateway_method.reporting-incidents_cors-options-mock-incident.http_method
+  status_code = aws_api_gateway_method_response.reporting-incidents_cors-options-mock_resource.status_code
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
+    "method.response.header.Access-Control-Allow-Methods" = "'OPTIONS,GET'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+  }
+
+  response_templates = {
+    "application/json" = ""
+  }
 }
 
 # Api Gateway - BOT State


### PR DESCRIPTION
Enable cors for GET on api/v1/incident and /api/v1/incident/mock endpoints.

TBD if we really need to enable CORS in PROD or if we can access back and front end under same dns. Enabling for now for development reasons.