### PR TITLE
Enable SQS encryiption and grant kms access to roles

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -35,6 +35,11 @@ resource "aws_iam_role_policy_attachment" "api_exec_role" {
   policy_arn = aws_iam_policy.api_policy.arn
 }
 
+resource "aws_iam_role_policy_attachment" "apiSQSRole_kmsAccess" {
+  role       = aws_iam_role.apiSQS.name
+  policy_arn = aws_iam_policy.sqs-kms-key-policy.arn
+}
+
 resource "aws_iam_role" "reportsOnIncidents-lambda-role" {
   name = "lambda-role"
 
@@ -72,6 +77,11 @@ resource "aws_iam_role_policy_attachment" "reportsOnIncidents-sqs" {
   policy_arn = aws_iam_policy.reportsOnIncidents-sqs-policy.arn
 }
 
+resource "aws_iam_role_policy_attachment" "reportsOnIncidents-lambda-role_kmsAccess" {
+  role       = aws_iam_role.reportsOnIncidents-lambda-role.name
+  policy_arn = aws_iam_policy.sqs-kms-key-policy.arn
+}
+
 data "template_file" "bot-client-policy" {
   template = file("policies/bot-permission.json")
   vars = {
@@ -84,6 +94,11 @@ data "template_file" "bot-client-policy" {
 resource "aws_iam_role_policy" "lambda_exec_role" {
   role   = aws_iam_role.bot-client-lambda-role.id
   policy = data.template_file.bot-client-policy.rendered
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_exec_role_kmsAccess" {
+  role   = aws_iam_role.bot-client-lambda-role.name
+  policy_arn = aws_iam_policy.sqs-kms-key-policy.arn
 }
 
 resource "aws_iam_role" "bot-client-lambda-role" {

--- a/terraform/kms.tf
+++ b/terraform/kms.tf
@@ -1,0 +1,33 @@
+resource "aws_kms_key" "sqs-key" {
+  description         = "Customer managed key for SQS"
+  enable_key_rotation = true
+}
+
+resource "aws_kms_alias" "sqs-key-alias" {
+  name          = "alias/ugt/sqs"
+  target_key_id = aws_kms_key.sqs-key.key_id
+}
+
+data "aws_iam_policy_document" "sqs-kms-key-policy-document" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+      "kms:GenerateDataKeyWithoutPlaintext",
+      "kms:GenerateDataKeyPairWithoutPlaintext",
+      "kms:GenerateDataKeyPair"
+    ]
+
+    resources = [
+      aws_kms_key.sqs-key.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "sqs-kms-key-policy" {
+  name   = "sqs-kms-key-policy"
+  path   = "/c/"
+  policy = data.aws_iam_policy_document.sqs-kms-key-policy-document.json
+}

--- a/terraform/sqs.tf
+++ b/terraform/sqs.tf
@@ -2,6 +2,7 @@ resource "aws_sqs_queue" "reporting-incidents_sqs" {
   name                      = "reporting-incidents-queue"
   delay_seconds             = 0
   receive_wait_time_seconds = 10
+  kms_master_key_id = aws_kms_alias.sqs-key-alias.name
 
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.reporting-incidents_sqs-dlq.arn
@@ -13,4 +14,5 @@ resource "aws_sqs_queue" "reporting-incidents_sqs-dlq" {
   name                      = "reporting-incidents-dlq"
   delay_seconds             = 0
   receive_wait_time_seconds = 10
+  kms_master_key_id = aws_kms_alias.sqs-key-alias.name
 }


### PR DESCRIPTION
1. Create KMS key
2. Enable SQS encryption with key created
3. Create policy for key access
4. Attach policy to roles used by lambdas